### PR TITLE
Revert swift_versions in podspec

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -83,4 +83,4 @@ jobs:
           gem install bundler -v 1.17.3
           bundle install --without documentation --path=vendor/bundle --jobs=3 --retry=3
       - name: Lint podspec
-        run: bundle exec pod lib lint
+        run: bundle exec pod lib lint --swift-version=5.0 --verbose

--- a/ApolloDeveloperKit.podspec
+++ b/ApolloDeveloperKit.podspec
@@ -11,7 +11,6 @@ Pod::Spec.new do |spec|
   spec.license      = { :type => "MIT", :file => "LICENSE" }
   spec.authors             = { "Ryosuke Ito" => "rito.0305@gmail.com" }
   spec.platform     = :ios, "9.0"
-  spec.swift_versions = "4.0", "4.2", "5.0"
   spec.source       = { :git => "https://github.com/manicmaniac/ApolloDeveloperKit.git", :tag => "#{spec.version}" }
   spec.source_files  = "Sources/Classes/**/*.swift"
   spec.resource = "Sources/Assets"

--- a/README.md
+++ b/README.md
@@ -36,21 +36,11 @@ Installation
 Add the following lines to your Podfile.
 
 ```
-supports_swift_versions '~> 4.0' # Only needed for Xcode 10.1 users
-
 pod 'Apollo'
 pod 'ApolloDeveloperKit'
 ```
 
 Then run `pod install`.
-
-#### For Xcode 10.1 (Swift 4.2)
-
-If you are using Xcode 10.1, where Swift 5 is not available, you need to specify your target's Swift version explicitly with `supports_swift_versions`.
-Since `ApolloDeveloperKit` is compatible with both Swift 4 and 5, CocoaPods automatically can select the compiler according to that value.
-Otherwise CocoaPods configures `ApolloDeveloperKit` as Swift 5 framework and your future builds would fail due to module incompatibility.
-
-Not recommended but as plan B, you can use `ApolloDeveloperKit ~> 0.3.3` which only supports Swift 4.2 as well.
 
 ### Install from Carthage
 


### PR DESCRIPTION
Since `swift_versions` has been introduced in CocoaPods 1.7.0, specifying it prevents older CocoaPods users from installing `ApolloDeveloperKit`.