### PR TITLE
Quit using `XCContext.runActivity(named:)`

### DIFF
--- a/Tests/Classes/ApolloDebugServerTests.swift
+++ b/Tests/Classes/ApolloDebugServerTests.swift
@@ -349,100 +349,116 @@ class ApolloDebugServerTests: XCTestCase {
         waitForExpectations(timeout: 10.0, handler: nil)
     }
 
-    func testPostRequest() {
+    func testPostRequest_withQuery() {
         let url = type(of: self).server.serverURL!.appendingPathComponent("request")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        XCTContext.runActivity(named: "with query") { _ in
-            request.httpBody = query
-            let expectation = self.expectation(description: "response should be received")
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                defer { expectation.fulfill() }
-                if let error = error {
-                    return XCTFail(String(describing: error))
-                }
-                guard let response = response as? HTTPURLResponse else {
-                    return XCTFail("unexpected response type")
-                }
-                XCTAssertEqual(response.statusCode, 200)
-                XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
-                guard let data = data else {
-                    fatalError("URLSession.dataTask(with:) must pass either of error or data")
-                }
-                guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
-                    return XCTFail("failed to parse JSON response")
-                }
-                XCTAssertEqual(jsonObject, queryResponseJSONObject)
+        request.httpBody = query
+        let expectation = self.expectation(description: "response should be received")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { expectation.fulfill() }
+            if let error = error {
+                return XCTFail(String(describing: error))
             }
-            task.resume()
-            waitForExpectations(timeout: 10.0, handler: nil)
-        }
-        XCTContext.runActivity(named: "with mutation") { _ in
-            request.httpBody = mutation
-            let expectation = self.expectation(description: "response should be received")
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                defer { expectation.fulfill() }
-                if let error = error {
-                    return XCTFail(String(describing: error))
-                }
-                guard let response = response as? HTTPURLResponse else {
-                    return XCTFail("unexpected response type")
-                }
-                XCTAssertEqual(response.statusCode, 200)
-                XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
-                guard let data = data else {
-                    fatalError("URLSession.dataTask(with:) must pass either of error or data")
-                }
-                guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
-                    return XCTFail("failed to parse JSON response")
-                }
-                XCTAssertEqual(jsonObject, mutationResponseJSONObject)
+            guard let response = response as? HTTPURLResponse else {
+                return XCTFail("unexpected response type")
             }
-            task.resume()
-            waitForExpectations(timeout: 10.0, handler: nil)
-        }
-        XCTContext.runActivity(named: "when a server error occurs") { _ in
-            request.httpBody = serverError
-            let expectation = self.expectation(description: "response should be received")
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                defer { expectation.fulfill() }
-                if let error = error {
-                    return XCTFail(String(describing: error))
-                }
-                guard let response = response as? HTTPURLResponse else {
-                    return XCTFail("unexpected response type")
-                }
-                XCTAssertEqual(response.statusCode, 400)
-                XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
-                guard let data = data else {
-                    fatalError("URLSession.dataTask(with:) must pass either of error or data")
-                }
-                guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
-                    return XCTFail("failed to parse JSON response")
-                }
-                XCTAssertEqual(jsonObject, serverErrorResponseJSONObject)
+            XCTAssertEqual(response.statusCode, 200)
+            XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
+            guard let data = data else {
+                fatalError("URLSession.dataTask(with:) must pass either of error or data")
             }
-            task.resume()
-            waitForExpectations(timeout: 10.0, handler: nil)
-        }
-        XCTContext.runActivity(named: "with 0 byte data") { _ in
-            request.httpBody = Data()
-            let expectation = self.expectation(description: "response should be received")
-            let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                defer { expectation.fulfill() }
-                if let error = error {
-                    return XCTFail(String(describing: error))
-                }
-                guard let response = response as? HTTPURLResponse else {
-                    return XCTFail("unexpected response type")
-                }
-                XCTAssertEqual(response.statusCode, 400)
+            guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
+                return XCTFail("failed to parse JSON response")
             }
-            task.resume()
-            waitForExpectations(timeout: 10.0, handler: nil)
+            XCTAssertEqual(jsonObject, queryResponseJSONObject)
         }
+        task.resume()
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testPostRequest_withMutation() {
+        let url = type(of: self).server.serverURL!.appendingPathComponent("request")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = mutation
+        let expectation = self.expectation(description: "response should be received")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { expectation.fulfill() }
+            if let error = error {
+                return XCTFail(String(describing: error))
+            }
+            guard let response = response as? HTTPURLResponse else {
+                return XCTFail("unexpected response type")
+            }
+            XCTAssertEqual(response.statusCode, 200)
+            XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
+            guard let data = data else {
+                fatalError("URLSession.dataTask(with:) must pass either of error or data")
+            }
+            guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
+                return XCTFail("failed to parse JSON response")
+            }
+            XCTAssertEqual(jsonObject, mutationResponseJSONObject)
+        }
+        task.resume()
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testPostRequest_whenAServerErrorOccurs() {
+        let url = type(of: self).server.serverURL!.appendingPathComponent("request")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = serverError
+        let expectation = self.expectation(description: "response should be received")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { expectation.fulfill() }
+            if let error = error {
+                return XCTFail(String(describing: error))
+            }
+            guard let response = response as? HTTPURLResponse else {
+                return XCTFail("unexpected response type")
+            }
+            XCTAssertEqual(response.statusCode, 400)
+            XCTAssertEqual(response.allHeaderFields["Content-Type"] as? String, "application/json")
+            guard let data = data else {
+                fatalError("URLSession.dataTask(with:) must pass either of error or data")
+            }
+            guard let jsonObject = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary else {
+                return XCTFail("failed to parse JSON response")
+            }
+            XCTAssertEqual(jsonObject, serverErrorResponseJSONObject)
+        }
+        task.resume()
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+
+    func testPostRequest_withZeroByteData() {
+        let url = type(of: self).server.serverURL!.appendingPathComponent("request")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data()
+        let expectation = self.expectation(description: "response should be received")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { expectation.fulfill() }
+            if let error = error {
+                return XCTFail(String(describing: error))
+            }
+            guard let response = response as? HTTPURLResponse else {
+                return XCTFail("unexpected response type")
+            }
+            XCTAssertEqual(response.statusCode, 400)
+        }
+        task.resume()
+        waitForExpectations(timeout: 10.0, handler: nil)
     }
 }
 

--- a/Tests/Classes/DebuggableNetworkTransportTests.swift
+++ b/Tests/Classes/DebuggableNetworkTransportTests.swift
@@ -11,34 +11,34 @@ import XCTest
 @testable import ApolloDeveloperKit
 
 class DebuggableNetworkTransportTests: XCTestCase {
-    func testSendOperationWithCompletionHandler() {
+    func testSendOperationWithCompletionHandler_whenResponseIsNotNilButErrorIsNil() {
         let operation = MockGraphQLQuery()
-        XCTContext.runActivity(named: "when response is not nil but error is nil") { _ in
-            let response = GraphQLResponse<MockGraphQLQuery>(operation: operation, body: ["foo": "bar"])
-            let networkTransport = DebuggableNetworkTransport(networkTransport: MockNetworkTransport(response: response, error: nil))
-            let expectation = self.expectation(description: "completionHandler should be called")
-            let cancellable = networkTransport.send(operation: operation) { response, error in
-                XCTAssertNotNil(response)
-                XCTAssertEqual(response?.body.count, 1)
-                XCTAssertNil(error)
-                expectation.fulfill()
-            }
-            XCTAssertTrue(cancellable is MockCancellable)
-            waitForExpectations(timeout: 0.25, handler: nil)
+        let response = GraphQLResponse<MockGraphQLQuery>(operation: operation, body: ["foo": "bar"])
+        let networkTransport = DebuggableNetworkTransport(networkTransport: MockNetworkTransport(response: response, error: nil))
+        let expectation = self.expectation(description: "completionHandler should be called")
+        let cancellable = networkTransport.send(operation: operation) { response, error in
+            XCTAssertNotNil(response)
+            XCTAssertEqual(response?.body.count, 1)
+            XCTAssertNil(error)
+            expectation.fulfill()
         }
-        XCTContext.runActivity(named: "when response is nil and error is not nil") { _ in
-            let response: GraphQLResponse<MockGraphQLQuery>? = nil
-            let urlError = URLError(.badURL)
-            let networkTransport = DebuggableNetworkTransport(networkTransport: MockNetworkTransport(response: response, error: urlError))
-            let expectation = self.expectation(description: "completionHandler should be called")
-            let cancellable = networkTransport.send(operation: operation) { response, error in
-                XCTAssertNil(response)
-                XCTAssertTrue(error as NSError? === urlError as NSError)
-                expectation.fulfill()
-            }
-            XCTAssertTrue(cancellable is MockCancellable)
-            waitForExpectations(timeout: 0.25, handler: nil)
+        XCTAssertTrue(cancellable is MockCancellable)
+        waitForExpectations(timeout: 0.25, handler: nil)
+    }
+
+    func testSendOperationWithCompletionHandler_whenResponseIsNilAndErrorIsNotNil() {
+        let operation = MockGraphQLQuery()
+        let response: GraphQLResponse<MockGraphQLQuery>? = nil
+        let urlError = URLError(.badURL)
+        let networkTransport = DebuggableNetworkTransport(networkTransport: MockNetworkTransport(response: response, error: urlError))
+        let expectation = self.expectation(description: "completionHandler should be called")
+        let cancellable = networkTransport.send(operation: operation) { response, error in
+            XCTAssertNil(response)
+            XCTAssertTrue(error as NSError? === urlError as NSError)
+            expectation.fulfill()
         }
+        XCTAssertTrue(cancellable is MockCancellable)
+        waitForExpectations(timeout: 0.25, handler: nil)
     }
 }
 

--- a/Tests/Classes/DebuggableNormalizedCacheTests.swift
+++ b/Tests/Classes/DebuggableNormalizedCacheTests.swift
@@ -18,22 +18,22 @@ class DebuggableNormalizedCacheTests: XCTestCase {
         underlyingCache = InMemoryNormalizedCache()
     }
 
-    func testLoadRecords() throws {
+    func testLoadRecords_whenUnderlyingCacheIsEmpty() throws {
         let cache = DebuggableNormalizedCache(cache: underlyingCache)
-        try XCTContext.runActivity(named: "when underlying cache is empty") { _ in
-            let records = try cache.loadRecords(forKeys: ["foo"]).await()
-            XCTAssertEqual(records.count, 1)
-            XCTAssertEqual(records.compactMap { $0 }.count, 0)
-        }
-        try XCTContext.runActivity(named: "when underlying cache is not empty") { _ in
-            let cachedFields: Record.Fields = ["bar": "baz"]
-            let cachedRecords: RecordSet = ["foo": cachedFields]
-            _ = try underlyingCache.merge(records: cachedRecords).await()
-            let records = try cache.loadRecords(forKeys: ["foo"]).await()
-            XCTAssertEqual(records.count, 1)
-            let cachedRecord = Record(key: "foo", cachedFields)
-            XCTAssertEqual(records.first??.key, cachedRecord.key)
-        }
+        let records = try cache.loadRecords(forKeys: ["foo"]).await()
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.compactMap { $0 }.count, 0)
+    }
+
+    func testLoadRecords_whenUnderlyingCacheIsNotEmpty() throws {
+        let cache = DebuggableNormalizedCache(cache: underlyingCache)
+        let cachedFields: Record.Fields = ["bar": "baz"]
+        let cachedRecords: RecordSet = ["foo": cachedFields]
+        _ = try underlyingCache.merge(records: cachedRecords).await()
+        let records = try cache.loadRecords(forKeys: ["foo"]).await()
+        XCTAssertEqual(records.count, 1)
+        let cachedRecord = Record(key: "foo", cachedFields)
+        XCTAssertEqual(records.first??.key, cachedRecord.key)
     }
 
     func testMerge() throws {

--- a/Tests/Classes/EventStream/EventStreamChunkTests.swift
+++ b/Tests/Classes/EventStream/EventStreamChunkTests.swift
@@ -10,14 +10,13 @@ import XCTest
 @testable import ApolloDeveloperKit
 
 class EventStreamChunkTests: XCTestCase {
-    func testData() {
-        XCTContext.runActivity(named: "when empty data given") { _ in
-            let chunk = EventStreamChunk()
-            XCTAssertEqual(chunk.data, "0\r\n\r\n".data(using: .utf8)!)
-        }
-        XCTContext.runActivity(named: "when nonempty data given") { _ in
-            let chunk = EventStreamChunk(rawData: "data: foo\n\n".data(using: .utf8)!)
-            XCTAssertEqual(chunk.data, "b\r\ndata: foo\n\n\r\n".data(using: .utf8)!)
-        }
+    func testData_withEmptyData() {
+        let chunk = EventStreamChunk()
+        XCTAssertEqual(chunk.data, "0\r\n\r\n".data(using: .utf8)!)
+    }
+
+    func testData_withNonemptyData() {
+        let chunk = EventStreamChunk(rawData: "data: foo\n\n".data(using: .utf8)!)
+        XCTAssertEqual(chunk.data, "b\r\ndata: foo\n\n\r\n".data(using: .utf8)!)
     }
 }

--- a/Tests/Classes/EventStream/EventStreamQueueMapTests.swift
+++ b/Tests/Classes/EventStream/EventStreamQueueMapTests.swift
@@ -25,27 +25,26 @@ class EventStreamQueueMapTests: XCTestCase {
         XCTAssertEqual(dequeuedChunk?.data, chunk.data)
     }
 
-    func testEnqueueForAllKeys() {
-        XCTContext.runActivity(named: "while key is being retained") { _ in
-            let queueMap = EventStreamQueueMap<NSObject>()
-            let chunk = EventStreamChunk()
+    func testEnqueueForAllKeys_whileKeyIsBeingRetained() {
+        let queueMap = EventStreamQueueMap<NSObject>()
+        let chunk = EventStreamChunk()
+        let key = NSObject()
+        queueMap.enqueue(chunk: chunk, forKey: key)
+        queueMap.enqueueForAllKeys(chunk: chunk)
+        var dequeuedChunk = queueMap.dequeue(key: key)
+        XCTAssertEqual(dequeuedChunk?.data, chunk.data)
+        dequeuedChunk = queueMap.dequeue(key: key)
+        XCTAssertEqual(dequeuedChunk?.data, chunk.data)
+    }
+
+    func testEnqueueForAllKeys_whileKeyIsBeingReleased() {
+        let queueMap = EventStreamQueueMap<NSObject>()
+        let chunk = EventStreamChunk()
+        do {
             let key = NSObject()
             queueMap.enqueue(chunk: chunk, forKey: key)
-            queueMap.enqueueForAllKeys(chunk: chunk)
-            var dequeuedChunk = queueMap.dequeue(key: key)
-            XCTAssertEqual(dequeuedChunk?.data, chunk.data)
-            dequeuedChunk = queueMap.dequeue(key: key)
-            XCTAssertEqual(dequeuedChunk?.data, chunk.data)
         }
-        XCTContext.runActivity(named: "while key is being released") { _ in
-            let queueMap = EventStreamQueueMap<NSObject>()
-            let chunk = EventStreamChunk()
-            do {
-                let key = NSObject()
-                queueMap.enqueue(chunk: chunk, forKey: key)
-            }
-            queueMap.enqueueForAllKeys(chunk: chunk)
-            XCTAssertTrue(queueMap.isEmpty)
-        }
+        queueMap.enqueueForAllKeys(chunk: chunk)
+        XCTAssertTrue(queueMap.isEmpty)
     }
 }

--- a/Tests/Classes/EventStream/EventStreamQueueTests.swift
+++ b/Tests/Classes/EventStream/EventStreamQueueTests.swift
@@ -11,50 +11,47 @@ import XCTest
 @testable import ApolloDeveloperKit
 
 class EventStreamQueueTests: XCTestCase {
-    func testDequeue() {
-        XCTContext.runActivity(named: "when empty") { _ in
-            let operationQueue = OperationQueue()
-            operationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name)"
-            let operation = BlockOperation {
-                let queue = EventStreamQueue()
-                _ = queue.dequeue()
-                XCTFail("dequeue should never finishes")
-            }
-            operationQueue.addOperation(operation)
-            Thread.sleep(forTimeInterval: 0.25)
-            operation.cancel()
+    func testDequeue_whenEmpty() {
+        let operationQueue = OperationQueue()
+        operationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name)"
+        let operation = BlockOperation {
+            let queue = EventStreamQueue()
+            _ = queue.dequeue()
+            XCTFail("dequeue should never finishes")
         }
+        operationQueue.addOperation(operation)
+        Thread.sleep(forTimeInterval: 0.25)
+        operation.cancel()
     }
 
-    func testEnqueueAndDequeue() {
-        XCTContext.runActivity(named: "in the main thread") { _ in
-            let queue = EventStreamQueue()
-            let chunk = EventStreamChunk()
+    func testEnqueueAndDequeue_whenInMainThread() {
+        let queue = EventStreamQueue()
+        let chunk = EventStreamChunk()
+        queue.enqueue(chunk: chunk)
+        let dequeuedChunk = queue.dequeue()
+        XCTAssertEqual(dequeuedChunk.data, chunk.data)
+    }
+
+    func testEnqueueAndDequeue_whenInDifferentThreads() {
+        let queue = EventStreamQueue()
+        let chunk = EventStreamChunk()
+        let expectationForEnqueue = expectation(description: "enqueue should finish")
+        let enqueueOperationQueue = OperationQueue()
+        enqueueOperationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name).enqueue"
+        let enqueueOperation = BlockOperation {
             queue.enqueue(chunk: chunk)
+            expectationForEnqueue.fulfill()
+        }
+        let expectationForDequeue = expectation(description: "dequeue should finish")
+        let dequeueOperationQueue = OperationQueue()
+        dequeueOperationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name).dequeue"
+        let dequeueOperation = BlockOperation {
             let dequeuedChunk = queue.dequeue()
             XCTAssertEqual(dequeuedChunk.data, chunk.data)
+            expectationForDequeue.fulfill()
         }
-        XCTContext.runActivity(named: "in the different threads") { _ in
-            let queue = EventStreamQueue()
-            let chunk = EventStreamChunk()
-            let expectationForEnqueue = expectation(description: "enqueue should finish")
-            let enqueueOperationQueue = OperationQueue()
-            enqueueOperationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name).enqueue"
-            let enqueueOperation = BlockOperation {
-                queue.enqueue(chunk: chunk)
-                expectationForEnqueue.fulfill()
-            }
-            let expectationForDequeue = expectation(description: "dequeue should finish")
-            let dequeueOperationQueue = OperationQueue()
-            dequeueOperationQueue.name = "com.github.manicmaniac.ApolloDeveloperKitTests.\(name).dequeue"
-            let dequeueOperation = BlockOperation {
-                let dequeuedChunk = queue.dequeue()
-                XCTAssertEqual(dequeuedChunk.data, chunk.data)
-                expectationForDequeue.fulfill()
-            }
-            enqueueOperationQueue.addOperation(enqueueOperation)
-            dequeueOperationQueue.addOperation(dequeueOperation)
-            waitForExpectations(timeout: 0.25, handler: nil)
-        }
+        enqueueOperationQueue.addOperation(enqueueOperation)
+        dequeueOperationQueue.addOperation(dequeueOperation)
+        waitForExpectations(timeout: 0.25, handler: nil)
     }
 }

--- a/Tests/Classes/WebServer/NetworkInterfaceTests.swift
+++ b/Tests/Classes/WebServer/NetworkInterfaceTests.swift
@@ -10,19 +10,20 @@ import XCTest
 @testable import ApolloDeveloperKit
 
 class NetworkInterfaceTests: XCTestCase {
-    func testIsUp() {
+    func testIsUp_whenTheInterfaceIsUp() {
         var name = "en0".cString(using: .ascii)!
         var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_ANY, port: 80)
-        XCTContext.runActivity(named: "when the interface is up") { _ in
-            let address = ifaddrs(name: &name, flags: IFF_UP, ifa_addr: &socketAddress)
-            let networkInterface = NetworkInterface(addr: address)
-            XCTAssertTrue(networkInterface.isUp)
-        }
-        XCTContext.runActivity(named: "when the interface is down") { _ in
-            let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
-            let networkInterface = NetworkInterface(addr: address)
-            XCTAssertFalse(networkInterface.isUp)
-        }
+        let address = ifaddrs(name: &name, flags: IFF_UP, ifa_addr: &socketAddress)
+        let networkInterface = NetworkInterface(addr: address)
+        XCTAssertTrue(networkInterface.isUp)
+    }
+
+    func testIsUp_whenTheInterfaceIsDown() {
+        var name = "en0".cString(using: .ascii)!
+        var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_ANY, port: 80)
+        let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
+        let networkInterface = NetworkInterface(addr: address)
+        XCTAssertFalse(networkInterface.isUp)
     }
 
     func testName() {
@@ -41,19 +42,19 @@ class NetworkInterfaceTests: XCTestCase {
         XCTAssertEqual(socketAddress.sa_family, networkInterface.socketFamily)
     }
 
-    func testIpv4Address() {
+    func testIpv4Address_whenTheInterfaceAddressIsINADDR_ANY() {
         var name = "en0".cString(using: .ascii)!
-        XCTContext.runActivity(named: "when the interface address is INADDR_ANY") { _ in
-            var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_ANY, port: 80)
-            let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
-            let networkInterface = NetworkInterface(addr: address)
-            XCTAssertEqual("0.0.0.0", networkInterface.ipv4Address)
-        }
-        XCTContext.runActivity(named: "when the interface address is INADDR_LOOPBACK") { _ in
-            var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_LOOPBACK, port: 80)
-            let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
-            let networkInterface = NetworkInterface(addr: address)
-            XCTAssertEqual("127.0.0.1", networkInterface.ipv4Address)
-        }
+        var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_ANY, port: 80)
+        let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
+        let networkInterface = NetworkInterface(addr: address)
+        XCTAssertEqual("0.0.0.0", networkInterface.ipv4Address)
+    }
+
+    func testIpv4Address_whenTheInterfaceAddressIsINADDR_LOOPBACK() {
+        var name = "en0".cString(using: .ascii)!
+        var socketAddress = sockaddr.in(family: AF_INET, address: INADDR_LOOPBACK, port: 80)
+        let address = ifaddrs(name: &name, flags: 0, ifa_addr: &socketAddress)
+        let networkInterface = NetworkInterface(addr: address)
+        XCTAssertEqual("127.0.0.1", networkInterface.ipv4Address)
     }
 }


### PR DESCRIPTION
Because it organizes outputs by methods, readability of test reports became worse.