### PR TITLE
Disable parallel testing

### DIFF
--- a/ApolloDeveloperKit.xcodeproj/xcshareddata/xcschemes/ApolloDeveloperKit.xcscheme
+++ b/ApolloDeveloperKit.xcodeproj/xcshareddata/xcschemes/ApolloDeveloperKit.xcscheme
@@ -32,7 +32,6 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"


### PR DESCRIPTION
- It's fast enough even without parallel testing
- Parallel testing is not supported by `xcpretty`
- Tests around `HTTPServer` randomly fails