### PR TITLE
Use more strict access modifiers

### DIFF
--- a/Sources/Classes/ApolloDebugServer.swift
+++ b/Sources/Classes/ApolloDebugServer.swift
@@ -125,7 +125,7 @@ public class ApolloDebugServer {
 // MARK: - HTTPRequestHandler
 
 extension ApolloDebugServer: HTTPRequestHandler {
-    public func server(_ server: HTTPServer, didReceiveRequest request: HTTPRequest, connection: HTTPConnection) {
+    func server(_ server: HTTPServer, didReceiveRequest request: HTTPRequest, connection: HTTPConnection) {
         switch (request.method, request.url.path) {
         case ("HEAD", "/events"):
             respondToRequestForEventSource(connection: connection, withBody: false)

--- a/Sources/Classes/EventStream/EventStreamChunk.swift
+++ b/Sources/Classes/EventStream/EventStreamChunk.swift
@@ -16,7 +16,7 @@ import Foundation
  *
  * - SeeAlso: [IETF RFC 7230](https://tools.ietf.org/html/rfc7230#section-4.1)
  */
-public struct EventStreamChunk {
+struct EventStreamChunk {
     private let rawData: Data
 
     init(rawData: Data = Data()) {

--- a/Sources/Classes/GraphQL/AnyGraphQLSelectionSet.swift
+++ b/Sources/Classes/GraphQL/AnyGraphQLSelectionSet.swift
@@ -11,12 +11,12 @@ import Apollo
 /**
  * A type erasure class for `GraphQLSelectionSet`.
  */
-public class AnyGraphQLSelectionSet: GraphQLSelectionSet {
-    public static var selections = [GraphQLSelection]()
+class AnyGraphQLSelectionSet: GraphQLSelectionSet {
+    static var selections = [GraphQLSelection]()
 
-    public var resultMap: ResultMap
+    var resultMap: ResultMap
 
-    public required init(unsafeResultMap: ResultMap) {
+    required init(unsafeResultMap: ResultMap) {
         self.resultMap = unsafeResultMap
     }
 }

--- a/Sources/Classes/GraphQL/GraphQLRequest.swift
+++ b/Sources/Classes/GraphQL/GraphQLRequest.swift
@@ -15,35 +15,35 @@ import Apollo
  * It doesn't cause a problem for now because it matters only when an operation is saved,
  * and ApolloDeveloperKit won't save any kind of operation given from devtool's GraphiQL.
  */
-public class GraphQLRequest: GraphQLOperation {
-    public typealias Data = AnyGraphQLSelectionSet
+class GraphQLRequest: GraphQLOperation {
+    typealias Data = AnyGraphQLSelectionSet
 
     /**
      * The type of an actual operation.
      *
      * Always be a GraphQLOperationType.query even if it isn't a query.
      */
-    public let operationType: GraphQLOperationType
+    let operationType: GraphQLOperationType
 
     /**
      * The query document of an operation.
      */
-    public let operationDefinition: String
+    let operationDefinition: String
 
     /**
      * The identifier of an operation.
      */
-    public var operationIdentifier: String?
+    var operationIdentifier: String?
 
     /**
      * The name of an operation.
      */
-    public var operationName: String
+    var operationName: String
 
     /**
      * The query variables of an operation.
      */
-    public let variables: GraphQLMap?
+    let variables: GraphQLMap?
 
     /**
      * Initializes a GraphQLRequest object.
@@ -51,7 +51,7 @@ public class GraphQLRequest: GraphQLOperation {
      * - Parameter jsonObject: JSON dictionary object that conforms to GraphQL request.
      * - Throws: `JSONDecodableError` when JSON could not be converted to GraphQL request.
      */
-    public convenience init(jsonObject: Any) throws {
+    convenience init(jsonObject: Any) throws {
         if let jsonObject = jsonObject as? [String: Any], let query = jsonObject["query"] as? String {
             let operationName = jsonObject["operationName"] as? String ?? ""
             let variables = jsonObject["variables"].flatMap(GraphQLRequest.convertToGraphQLMap(_:))

--- a/Sources/Classes/JSON/JSError.swift
+++ b/Sources/Classes/JSON/JSError.swift
@@ -11,7 +11,7 @@ import Apollo
 /**
  * `JSError` bridges Swift error and JavaScript error.
  */
-public struct JSError {
+struct JSError {
     /**
      * The localized message describing this error.
      */
@@ -44,7 +44,7 @@ public struct JSError {
     // MARK: - JSONEncodable
 
 extension JSError: JSONEncodable {
-    public var jsonValue: JSONValue {
+    var jsonValue: JSONValue {
         return [
             "message": message.jsonValue,
             "fileName": fileName.jsonValue,

--- a/Sources/Classes/Store/MutationStore.swift
+++ b/Sources/Classes/Store/MutationStore.swift
@@ -13,7 +13,7 @@ import Apollo
  *
  * This class is Swift implementation of `apollo-client`'s `MutationStoreValue`.
  */
-public struct MutationStoreValue {
+struct MutationStoreValue {
     let mutation: String
     let variables: GraphQLMap?
     var loading: Bool
@@ -23,7 +23,7 @@ public struct MutationStoreValue {
 // MARK: JSONEncodable
 
 extension MutationStoreValue: JSONEncodable {
-    public var jsonValue: JSONValue {
+    var jsonValue: JSONValue {
         return [
             "mutation": mutation,
             "variables": variables.jsonValue,
@@ -41,7 +41,7 @@ extension MutationStoreValue: JSONEncodable {
  *
  * - SeeAlso: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/data/mutations.ts
  */
-public class MutationStore {
+class MutationStore {
     private(set) var store = [String: MutationStoreValue]()
 
     func get(mutationId: String) -> MutationStoreValue? {

--- a/Sources/Classes/Store/QueryStore.swift
+++ b/Sources/Classes/Store/QueryStore.swift
@@ -13,7 +13,7 @@ import Apollo
  *
  * This class is Swift implementation of `apollo-client`'s `QueryStoreValue`.
  */
-public struct QueryStoreValue {
+struct QueryStoreValue {
     let document: String
     let variables: GraphQLMap?
     var previousVariables: GraphQLMap?
@@ -24,7 +24,7 @@ public struct QueryStoreValue {
 // MARK: JSONEncodable
 
 extension QueryStoreValue: JSONEncodable {
-    public var jsonValue: JSONValue {
+    var jsonValue: JSONValue {
         return [
             "document": document,
             "variables": variables.jsonValue,
@@ -43,7 +43,7 @@ extension QueryStoreValue: JSONEncodable {
  *
  * - SeeAlso: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/data/queries.ts
  */
-public class QueryStore {
+class QueryStore {
     private(set) var store = [String: QueryStoreValue]()
 
     func get(queryId: String) -> QueryStoreValue? {

--- a/Sources/Classes/WebServer/HTTPConnection.swift
+++ b/Sources/Classes/WebServer/HTTPConnection.swift
@@ -12,7 +12,7 @@ protocol HTTPConnectionDelegate: class {
     func httpConnectionWillClose(_ connection: HTTPConnection)
 }
 
-public class HTTPConnection {
+class HTTPConnection {
     let fileHandle: FileHandle
     weak var delegate: HTTPConnectionDelegate?
 
@@ -37,11 +37,11 @@ public class HTTPConnection {
 // MARK: Hashable
 
 extension HTTPConnection: Hashable {
-    public static func == (lhs: HTTPConnection, rhs: HTTPConnection) -> Bool {
+    static func == (lhs: HTTPConnection, rhs: HTTPConnection) -> Bool {
         return lhs.fileHandle == rhs.fileHandle
     }
 
-    public func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(fileHandle)
     }
 }

--- a/Sources/Classes/WebServer/HTTPIncomingRequest.swift
+++ b/Sources/Classes/WebServer/HTTPIncomingRequest.swift
@@ -13,7 +13,7 @@ protocol HTTPIncomingRequestDelegate: class {
     func httpIncomingRequest(_ incomingRequest: HTTPIncomingRequest, didFinishWithRequest request: HTTPRequest, connection: HTTPConnection)
 }
 
-public class HTTPIncomingRequest {
+class HTTPIncomingRequest {
     let fileHandle: FileHandle
     let message = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true).takeRetainedValue()
     private weak var delegate: HTTPIncomingRequestDelegate?
@@ -84,11 +84,11 @@ public class HTTPIncomingRequest {
 // MARK: Hashable
 
 extension HTTPIncomingRequest: Hashable {
-    public static func == (lhs: HTTPIncomingRequest, rhs: HTTPIncomingRequest) -> Bool {
+    static func == (lhs: HTTPIncomingRequest, rhs: HTTPIncomingRequest) -> Bool {
         return lhs.fileHandle == rhs.fileHandle
     }
 
-    public func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         hasher.combine(fileHandle)
     }
 }

--- a/Sources/Classes/WebServer/HTTPRequest.swift
+++ b/Sources/Classes/WebServer/HTTPRequest.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * A Swifty wrapper for CFHTTPMessage instantiated as a request.
  */
-public class HTTPRequest {
+class HTTPRequest {
     private let message: CFHTTPMessage
 
     init(message: CFHTTPMessage) {

--- a/Sources/Classes/WebServer/HTTPResponse.swift
+++ b/Sources/Classes/WebServer/HTTPResponse.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  * A Swifty wrapper for CFHTTPMessage instantiated as a response.
  */
-public class HTTPResponse {
+class HTTPResponse {
     private let message: CFHTTPMessage
 
     private static var dateFormatter: DateFormatter = {

--- a/Sources/Classes/WebServer/HTTPServer.swift
+++ b/Sources/Classes/WebServer/HTTPServer.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  * The protocol to handle raw HTTP request the server receives.
  */
-public protocol HTTPRequestHandler: class {
+protocol HTTPRequestHandler: class {
     /**
      * Invoked when the server receives a HTTP request.
      *
@@ -36,7 +36,7 @@ private let invalidBackgroundTaskIdentifier = UIBackgroundTaskInvalid
  *
  * - SeeAlso: https://www.cocoawithlove.com/2009/07/simple-extensible-http-server-in-cocoa.html
  */
-public class HTTPServer {
+class HTTPServer {
     private enum State {
         case idle
         case starting

--- a/Sources/Classes/WebServer/NetworkInterface.swift
+++ b/Sources/Classes/WebServer/NetworkInterface.swift
@@ -11,32 +11,32 @@ import Darwin
 /**
  * `NetworkInterface` is a Swift bridge for Unix `ifaddrs`.
  */
-public class NetworkInterface {
+class NetworkInterface {
     /**
      * Name of this interface.
      */
-    public let name: String
+    let name: String
     private let addressPointer: UnsafeMutablePointer<sockaddr>
     private let flags: UInt32
 
     /**
      * Boolean value representing whether if this interface is up or down.
      */
-    public var isUp: Bool {
+    var isUp: Bool {
         return (flags & UInt32(IFF_UP)) == 1
     }
 
     /**
      * Socket family of this interface.
      */
-    public var socketFamily: sa_family_t {
+    var socketFamily: sa_family_t {
         return addressPointer.pointee.sa_family
     }
 
     /**
      * IPv4 address tied up with this interface.
      */
-    public var ipv4Address: String? {
+    var ipv4Address: String? {
         let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: Int(NI_MAXHOST))
         defer { buffer.deallocate() }
         guard getnameinfo(addressPointer,

--- a/Sources/Classes/WebServer/NetworkInterfaceList.swift
+++ b/Sources/Classes/WebServer/NetworkInterfaceList.swift
@@ -11,14 +11,14 @@ import Darwin
 /**
  * `NetworkInterfaceList` is a linked list of `NetworkInterface`s.
  */
-public class NetworkInterfaceList: Sequence {
-    public typealias Element = NetworkInterface
-    public typealias Iterator = AnyIterator<NetworkInterface>
+class NetworkInterfaceList: Sequence {
+    typealias Element = NetworkInterface
+    typealias Iterator = AnyIterator<NetworkInterface>
 
     /**
      * Returns newly initialized instance with the current device's state of network interfaces.
      */
-    public class var current: NetworkInterfaceList? {
+    class var current: NetworkInterfaceList? {
         var addressPointer: UnsafeMutablePointer<ifaddrs>!
         guard withUnsafeMutablePointer(to: &addressPointer, getifaddrs) >= 0 else {
             return nil
@@ -42,7 +42,7 @@ public class NetworkInterfaceList: Sequence {
         self.addressPointer = addressPointer
     }
 
-    public func makeIterator() -> Iterator {
+    func makeIterator() -> Iterator {
         let addressPointers = sequence(first: addressPointer, next: { $0.pointee.ifa_next })
         let networkInterfaces = addressPointers.lazy.map { NetworkInterface(addr: $0.pointee) }
         return AnyIterator(networkInterfaces.makeIterator())


### PR DESCRIPTION
Since I started developing `ApolloDeveloperKit` with Xcode10.1 where even `@testable` doesn't support importing `internal` classes, I added `public` modifiers to the most of classes unnecessary for users.

Now I would like to start using Xcode10.2 or later where `@testable` support importing `internal` classes and finally I can remove those unnecessarily `public` modifiers.

This could be a breaking change for users so it should be released as a new version.