### PR TITLE
Update to Xcode 11

### DIFF
--- a/ApolloDeveloperKit.xcodeproj/project.pbxproj
+++ b/ApolloDeveloperKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -70,6 +70,8 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.erb";
 			fileType = pattern.proxy;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)",
@@ -81,6 +83,8 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.erb";
 			fileType = pattern.proxy;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)",

--- a/ApolloDeveloperKit.xcodeproj/project.pbxproj
+++ b/ApolloDeveloperKit.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)",
 			);
+			runOncePerArchitecture = 0;
 			script = "erb -T - \"$SCRIPT_INPUT_FILE\" >\"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
 		5B5D4350233F817900AF5B5C /* PBXBuildRule */ = {
@@ -89,6 +90,7 @@
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE)",
 			);
+			runOncePerArchitecture = 0;
 			script = "erb -T - \"$SCRIPT_INPUT_FILE\" >\"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
 /* End PBXBuildRule section */


### PR DESCRIPTION
Start using Xcode 11.1 to develop `ApolloDeveloperKit` without updating the version to install it.
The project still supports Xcode 10.1 or above to install the library.