### PR TITLE
Do not listen twice

### DIFF
--- a/Sources/Classes/WebServer/HTTPServer.swift
+++ b/Sources/Classes/WebServer/HTTPServer.swift
@@ -125,9 +125,6 @@ class HTTPServer {
             @unknown default:
                 throw HTTPServerError.socketSetAddressFailed
             }
-            if listen(fileDescriptor, 16) != 0 {
-                throw HTTPServerError.socketListenFailed
-            }
         } catch let error {
             CFSocketInvalidate(socket)
             throw error


### PR DESCRIPTION
`CFSocketSetAddress()` automatically listen the given address once it binds
the address.
Thus invoking `listen(2)` is unnecessary.

> This function binds the socket by calling bind, and if the socket
supports it, configures the socket for listening by calling listen with
a backlog of 256.

- https://developer.apple.com/documentation/corefoundation/1542729-cfsocketsetaddress
- https://opensource.apple.com/source/CF/CF-635/CFSocket.c.auto.html