### PR TITLE
Avoid crash when array is cached

### DIFF
--- a/ApolloDeveloperKit.xcodeproj/project.pbxproj
+++ b/ApolloDeveloperKit.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		5BB8BE2B2377CB3A004D93B3 /* URLSessionConfiguration+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB8BE2A2377CB3A004D93B3 /* URLSessionConfiguration+Test.swift */; };
 		5BBBF5E02340CAF500D64D7A /* MIMEType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBBF5DF2340CAF500D64D7A /* MIMEType.swift */; };
 		5BC65865234E9F790019CF57 /* ConsoleRedirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC65864234E9F790019CF57 /* ConsoleRedirection.swift */; };
+		5BCC23BF238464A400D26A79 /* JSONCocoaTypeConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCC23BE238464A400D26A79 /* JSONCocoaTypeConversions.swift */; };
 		5BF045FD22B6E62D0083A52D /* JSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF045FC22B6E62D0083A52D /* JSError.swift */; };
 		5BF8112E2344FD7000115EB7 /* HTTPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF8112D2344FD7000115EB7 /* HTTPConnection.swift */; };
 		5BFF016722DF8BA600944131 /* ApolloDeveloperKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B26FC1C22B3DB0800359E63 /* ApolloDeveloperKit.framework */; };
@@ -246,6 +247,7 @@
 		5BB8BE2A2377CB3A004D93B3 /* URLSessionConfiguration+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionConfiguration+Test.swift"; sourceTree = "<group>"; };
 		5BBBF5DF2340CAF500D64D7A /* MIMEType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIMEType.swift; sourceTree = "<group>"; };
 		5BC65864234E9F790019CF57 /* ConsoleRedirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleRedirection.swift; sourceTree = "<group>"; };
+		5BCC23BE238464A400D26A79 /* JSONCocoaTypeConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCocoaTypeConversions.swift; sourceTree = "<group>"; };
 		5BE2444622E0F6ED008EDAAD /* Makefile */ = {isa = PBXFileReference; explicitFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; usesTabs = 1; };
 		5BF045FC22B6E62D0083A52D /* JSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSError.swift; sourceTree = "<group>"; };
 		5BF8112D2344FD7000115EB7 /* HTTPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPConnection.swift; sourceTree = "<group>"; };
@@ -497,6 +499,7 @@
 			isa = PBXGroup;
 			children = (
 				5BF045FC22B6E62D0083A52D /* JSError.swift */,
+				5BCC23BE238464A400D26A79 /* JSONCocoaTypeConversions.swift */,
 				5B2F84F922B4C8F40025A211 /* Record+JSONEncodable.swift */,
 				5B3A839022C72167002B4FFB /* Reference+JSONEncodable.swift */,
 			);
@@ -780,6 +783,7 @@
 				5B71522022DA007400002BA6 /* HTTPServerError.swift in Sources */,
 				5BF045FD22B6E62D0083A52D /* JSError.swift in Sources */,
 				5B67343A22BFC53A00A09DF7 /* GraphQLRequest.swift in Sources */,
+				5BCC23BF238464A400D26A79 /* JSONCocoaTypeConversions.swift in Sources */,
 				5B4F460B2370A8540039495A /* DarwinFileDescriptorDuplicator.swift in Sources */,
 				5BB8BE2B2377CB3A004D93B3 /* URLSessionConfiguration+Test.swift in Sources */,
 				5B8983CE237A3E3A00C857D6 /* BackgroundTask.swift in Sources */,

--- a/Sources/Classes/JSON/JSONCocoaTypeConversions.swift
+++ b/Sources/Classes/JSON/JSONCocoaTypeConversions.swift
@@ -1,0 +1,95 @@
+//
+//  JSONCocoaTypeConversions.swift
+//  ApolloDeveloperKit
+//
+//  Created by Ryosuke Ito on 11/20/19.
+//  Copyright © 2019 Ryosuke Ito. All rights reserved.
+//
+
+import Apollo
+
+/**
+ * `Apollo` has its own utility extensions to convert Swift standard types to JSON object and uses it widely in the project.
+ * `ApolloDeveloperKit` borrows this feature in order to convert an object to JSON-compliant object, like converting cache contents to JSON.
+ *  However, I found `Apollo` sometimes utilizes Cocoa types like NSString which is not covered by the above utility extensions,
+ *  and when I use those utility extensions on them, `fatalError()` occurs because it doesn't conform to `JSONEncodable`.
+ *  So to avoid this problem, `ApolloDeveloperKit` have to prepare some more extensions for Cocoa types.
+ */
+
+extension NSString: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as String).jsonValue
+    }
+}
+
+extension NSNumber: JSONEncodable {
+    public var jsonValue: JSONValue {
+        switch CFGetTypeID(self) {
+        case CFBooleanGetTypeID():
+            return boolValue.jsonValue
+        case CFNumberGetTypeID():
+            switch CFNumberGetType(self) {
+            case .floatType, .doubleType, .float32Type, .float64Type, .cgFloatType:
+                return doubleValue.jsonValue
+            default:
+                return intValue.jsonValue
+            }
+        default:
+            fatalError("The underlying type of value must be CFBoolean or CFNumber")
+        }
+    }
+}
+
+extension NSDictionary: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as! [AnyHashable: Any]).jsonValue
+    }
+}
+
+extension NSArray: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as! [Any]).jsonValue
+    }
+}
+
+extension NSNull: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return self
+    }
+}
+
+extension CFString: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as NSString).jsonValue
+    }
+}
+
+extension CFNumber: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as NSNumber).jsonValue
+    }
+}
+
+extension CFBoolean: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return CFBooleanGetValue(self).jsonValue
+    }
+}
+
+extension CFDictionary: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as NSDictionary).jsonValue
+    }
+}
+
+extension CFArray: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return (self as NSArray).jsonValue
+    }
+}
+
+extension CFNull: JSONEncodable {
+    public var jsonValue: JSONValue {
+        return self as NSNull
+    }
+}

--- a/Tests/Classes/JSON/Record+JSONEncodableTests.swift
+++ b/Tests/Classes/JSON/Record+JSONEncodableTests.swift
@@ -11,33 +11,87 @@ import XCTest
 @testable import ApolloDeveloperKit
 
 class Record_JSONEncodableTests: XCTestCase {
-    func testJSONValue() {
+    func testJSONValue_whenValueIsSwiftStandardType() {
         let record = Record(key: "key", [
             "String": "foo",
             "Int": 42,
+            "Double": 1.5,
             "Bool": true,
             "nil": nil as String? as Any,
-            "NSString": "foo" as NSString,
-            "NSNumber-Int": 42 as NSNumber,
-            "NSNumber-Bool": true as NSNumber,
-            "NSNull": NSNull(),
-            "CFString": "foo" as CFString,
-            "CFNumber-Int": 42 as CFNumber,
-            "CFNumber-Bool": true as CFNumber
+            "[String]": ["foo", "bar"],
+            "[[Int]]": [[0, 42]],
+            "[String: String]": ["foo": "bar"]
         ])
         guard let object = record.jsonValue as? [String: Any] else {
             return XCTFail()
         }
         XCTAssertEqual(object["String"] as? String, "foo")
         XCTAssertEqual(object["Int"] as? Int, 42)
+        XCTAssertEqual(object["Double"] as? Double, 1.5)
         XCTAssertEqual(object["Bool"] as? Bool, true)
         XCTAssertEqual(object["nil"] as? NSNull, NSNull())
-        XCTAssertEqual(object["NSString"] as? String, "foo")
-        XCTAssertEqual(object["NSNumber-Int"] as? Int, 42)
-        XCTAssertEqual(object["NSNumber-Bool"] as? Bool, true)
+        XCTAssertEqual(object["[String]"] as? [String], ["foo", "bar"])
+        XCTAssertEqual(object["[[Int]]"] as? [[Int]], [[0, 42]])
+        XCTAssertEqual(object["[String: String]"] as? [String: String], ["foo": "bar"])
+    }
+
+    func testJSONValue_whenValueIsFoundationClass() {
+        let record = Record(key: "key", [
+            "NSString": "foo" as NSString,
+            "NSNumber-Int": 42 as NSNumber,
+            "NSNumber-Double": 1.5 as NSNumber,
+            "NSNumber-Bool": true as NSNumber,
+            "NSNull": NSNull(),
+            "NSArray<NSString>": ["foo" as NSString, "bar" as NSString] as NSArray,
+            "NSArray<NSArray<NSNumber>>": [[0 as NSNumber, 42 as NSNumber] as NSArray] as NSArray,
+            "NSDictionary<NSString, NSString>": ["foo" as NSString: "bar" as NSString] as NSDictionary
+        ])
+        guard let object = record.jsonValue as? [String: Any] else {
+            return XCTFail()
+        }
+        XCTAssertEqual(object["NSString"] as? NSString, "foo")
+        XCTAssertEqual(object["NSNumber-Int"] as? NSNumber, 42)
+        XCTAssertEqual(object["NSNumber-Double"] as? NSNumber, 1.5)
+        XCTAssertEqual(object["NSNumber-Bool"] as? NSNumber, true)
         XCTAssertEqual(object["NSNull"] as? NSNull, NSNull())
-        XCTAssertEqual(object["CFString"] as? String, "foo")
-        XCTAssertEqual(object["CFNumber-Int"] as? Int, 42)
-        XCTAssertEqual(object["CFNumber-Bool"] as? Bool, true)
+        XCTAssertEqual(object["NSArray<NSString>"] as? NSArray, ["foo", "bar"])
+        XCTAssertEqual(object["NSArray<NSArray<NSNumber>>"] as? NSArray, [[0, 42]])
+        XCTAssertEqual(object["NSDictionary<NSString, NSString>"] as? [String: String], ["foo": "bar"])
+    }
+
+    func testJSONValue_whenValueIsCoreFoundationClass() {
+        let record = Record(key: "key", [
+            "CFString": "foo" as CFString,
+            "CFNumber-Int": 42 as CFNumber,
+            "CFNumber-Double": 1.5 as CFNumber,
+            "CFBoolean": true as CFBoolean,
+            "CFNull": kCFNull!,
+            "CFArray<CFString>": ["foo" as CFString, "bar" as CFString] as CFArray,
+            "CFArray<CFArray<CFNumber>>": [[0 as CFNumber, 42 as CFNumber] as CFArray] as CFArray,
+            "CFDictionary<CFString, CFString>": ["foo" as CFString: "bar" as CFString] as CFDictionary
+        ])
+        guard let object = record.jsonValue as? [String: Any] else {
+            return XCTFail()
+        }
+        XCTAssertEqual(object["CFString"] as! CFString, "foo" as CFString)
+        XCTAssertEqual(object["CFNumber-Int"] as! CFNumber, 42 as CFNumber)
+        XCTAssertEqual(object["CFNumber-Double"] as! CFNumber, 1.5 as CFNumber)
+        XCTAssertEqual(object["CFBoolean"] as! CFBoolean, true as CFBoolean)
+        XCTAssertEqual(object["CFNull"] as! CFNull, kCFNull!)
+        XCTAssertEqual(object["CFArray<CFString>"] as! CFArray, ["foo" as CFString, "bar" as CFString] as CFArray)
+        XCTAssertEqual(object["CFArray<CFArray<CFNumber>>"] as! CFArray, [[0 as CFNumber, 42 as CFNumber] as CFArray] as CFArray)
+        XCTAssertEqual(object["CFDictionary<CFString, CFString>"] as! CFDictionary, ["foo" as CFString: "bar" as CFString] as CFDictionary)
+    }
+
+    func testJSONValue_whenValueIsHybridType() {
+        let record = Record(key: "key", [
+            "[NSString]": ["foo" as NSString, "bar" as NSString],
+            "[NSString: Int]": ["foo" as NSString: 42]
+        ])
+        guard let object = record.jsonValue as? [String: Any] else {
+            return XCTFail()
+        }
+        XCTAssertEqual(object["[NSString]"] as? [NSString], ["foo", "bar"])
+        XCTAssertEqual(object["[NSString: Int]"] as? [NSString: Int], ["foo": 42])
     }
 }


### PR DESCRIPTION
When `NormalizedCache` object which is set to `ApolloStore` has an array as its content, a fatal error occurs during conversion to JSON.