### PR TITLE
Treat chunked encoding as an error

### DIFF
--- a/ApolloDeveloperKit.xcodeproj/project.pbxproj
+++ b/ApolloDeveloperKit.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5B2E1B2D230CC93C003C85CB /* NetworkInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2E1B2C230CC93C003C85CB /* NetworkInterfaceTests.swift */; };
 		5B2E1B36230CD1BA003C85CB /* ifaddrs+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2E1B35230CD1BA003C85CB /* ifaddrs+Factory.swift */; };
 		5B2E1B38230CD1D0003C85CB /* sockaddr+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2E1B37230CD1D0003C85CB /* sockaddr+Factory.swift */; };
+		5B2EFC7F240BBAAA003EC9D3 /* HTTPServerChunkedEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2EFC7E240BBAAA003EC9D3 /* HTTPServerChunkedEncodingTests.swift */; };
 		5B2F821822B430A80025A211 /* Apollo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B2F821322B430A80025A211 /* Apollo.framework */; };
 		5B2F84E522B4321E0025A211 /* DebuggableNormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2F84E422B4321E0025A211 /* DebuggableNormalizedCache.swift */; };
 		5B2F84E722B432730025A211 /* DebuggableNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2F84E622B432730025A211 /* DebuggableNetworkTransport.swift */; };
@@ -200,6 +201,7 @@
 		5B2E1B2C230CC93C003C85CB /* NetworkInterfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkInterfaceTests.swift; sourceTree = "<group>"; };
 		5B2E1B35230CD1BA003C85CB /* ifaddrs+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ifaddrs+Factory.swift"; sourceTree = "<group>"; };
 		5B2E1B37230CD1D0003C85CB /* sockaddr+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "sockaddr+Factory.swift"; sourceTree = "<group>"; };
+		5B2EFC7E240BBAAA003EC9D3 /* HTTPServerChunkedEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServerChunkedEncodingTests.swift; sourceTree = "<group>"; };
 		5B2F821322B430A80025A211 /* Apollo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Apollo.framework; path = Carthage/Build/iOS/Apollo.framework; sourceTree = "<group>"; };
 		5B2F84E422B4321E0025A211 /* DebuggableNormalizedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggableNormalizedCache.swift; sourceTree = "<group>"; };
 		5B2F84E622B432730025A211 /* DebuggableNetworkTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggableNetworkTransport.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 			children = (
 				5B207731236E0FD800817E45 /* HTTPChunkedResponseTests.swift */,
 				5B3A83AC22C93361002B4FFB /* HTTPServerTests.swift */,
+				5B2EFC7E240BBAAA003EC9D3 /* HTTPServerChunkedEncodingTests.swift */,
 				5B71522122DA00CB00002BA6 /* HTTPServerErrorTests.swift */,
 				5B9645DC236BB8BF00F0926D /* MIMETypeTests.swift */,
 				5B2E1B2C230CC93C003C85CB /* NetworkInterfaceTests.swift */,
@@ -828,6 +831,7 @@
 				5B71522222DA00CB00002BA6 /* HTTPServerErrorTests.swift in Sources */,
 				5BA76BC2240ABAB600501193 /* BackgroundTaskTests.swift in Sources */,
 				5B2E1B29230C2CE0003C85CB /* NetworkInterfaceListTests.swift in Sources */,
+				5B2EFC7F240BBAAA003EC9D3 /* HTTPServerChunkedEncodingTests.swift in Sources */,
 				5B0EC95E22B6D728003D7933 /* DebuggableNetworkTransportTests.swift.erb in Sources */,
 				5B3A838D22C6856D002B4FFB /* JSErrorTests.swift in Sources */,
 				5B16DECD23F45C5300EFEA16 /* MockNetworkTransport.swift.erb in Sources */,

--- a/Sources/Classes/ApolloDebugServer.swift
+++ b/Sources/Classes/ApolloDebugServer.swift
@@ -212,6 +212,10 @@ extension ApolloDebugServer: HTTPServerDelegate {
         }
     }
 
+    func server(_ server: HTTPServer, didFailToHandle request: URLRequest, connection: HTTPConnection, error: Error) {
+        respondError(to: request, in: connection, statusCode: 500, with: error.localizedDescription.data(using: .utf8)!)
+    }
+
     private func respond(to request: URLRequest, in connection: HTTPConnection, contentType: MIMEType?, contentLength: Int?, body: Data?) {
         let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: connection.httpVersion, headerFields: [
             "Content-Length": String(contentLength ?? body?.count ?? 0),

--- a/Sources/Classes/WebServer/HTTPServer.swift
+++ b/Sources/Classes/WebServer/HTTPServer.swift
@@ -24,10 +24,20 @@ protocol HTTPServerDelegate: class {
      * Invoked when the server receives a HTTP request.
      *
      * - Parameter server: The server receiving a HTTP request.
-     * - Parameter request: A raw HTTP message including header and complete body.
-     * - Parameter completion: A completion handler. You must call it when the response ends.
+     * - Parameter request: A raw HTTP request including header and complete body.
+     * - Parameter connection: An HTTP connection where the request received.
      */
     func server(_ server: HTTPServer, didReceiveRequest request: URLRequest, connection: HTTPConnection)
+
+    /**
+     * Invoked when a server error occurs in a HTTP connection.
+     *
+     * - Parameter server: The server receiving a HTTP request.
+     * - Parameter request: An HTTP request which caused the error. It must not have body part.
+     * - Parameter connection: An HTTP connection where the error occurred.
+     * - Parameter error: An error object describing why the server couldn't handle the request.     *
+     */
+    func server(_ server: HTTPServer, didFailToHandle request: URLRequest, connection: HTTPConnection, error: Error)
 }
 
 /**
@@ -145,6 +155,10 @@ extension HTTPServer: HTTPConnectionDelegate {
 
     func httpConnectionWillClose(_ connection: HTTPConnection) {
         connections.remove(connection)
+    }
+
+    func httpConnection(_ connection: HTTPConnection, didFailToHandle request: URLRequest, error: Error) {
+        delegate?.server(self, didFailToHandle: request, connection: connection, error: error)
     }
 }
 

--- a/Sources/Classes/WebServer/HTTPServerError.swift
+++ b/Sources/Classes/WebServer/HTTPServerError.swift
@@ -14,6 +14,7 @@ import Foundation
 public enum HTTPServerError: CustomNSError, LocalizedError {
     /// Thrown when multiple errors occurred while creating a new socket.
     case multipleSocketErrorOccurred([UInt16: Error])
+    case unsupportedBodyEncoding(String)
 
     public static let errorDomain = "HTTPServerErrorDomain"
 
@@ -21,6 +22,8 @@ public enum HTTPServerError: CustomNSError, LocalizedError {
         switch self {
         case .multipleSocketErrorOccurred:
             return 199
+        case .unsupportedBodyEncoding:
+            return 200
         }
     }
 
@@ -28,6 +31,8 @@ public enum HTTPServerError: CustomNSError, LocalizedError {
         switch self {
         case .multipleSocketErrorOccurred:
             return "Multiple error occurred while creating socket(s)."
+        case .unsupportedBodyEncoding(let encoding):
+            return "Failed to parse the given HTTP body encoded in \(encoding)."
         }
     }
 }

--- a/Tests/Classes/WebServer/HTTPServerErrorTests.swift
+++ b/Tests/Classes/WebServer/HTTPServerErrorTests.swift
@@ -17,9 +17,11 @@ class HTTPServerErrorTests: XCTestCase {
 
     func testErrorCode() {
         XCTAssertEqual(HTTPServerError.multipleSocketErrorOccurred([:]).errorCode, 199)
+        XCTAssertEqual(HTTPServerError.unsupportedBodyEncoding("chunked").errorCode, 200)
     }
 
     func testLocalizedDescription() {
         XCTAssertTrue((HTTPServerError.multipleSocketErrorOccurred([:]) as Error).localizedDescription.contains("Multiple"))
+        XCTAssertTrue((HTTPServerError.unsupportedBodyEncoding("chunked") as Error).localizedDescription.contains("chunked"))
     }
 }


### PR DESCRIPTION
As chunked encoding is not implemented and hasn't been handled properly, it should be treated as an error for now.

According to the source code of [CFHTTPServer.c](https://apple.co/2TfWW5T), it treats chunked encoding as an error as well.

Downgrading to HTTP 1.0 disables chunked encoding but we need to keep using HTTP 1.1, which defines chunked encoding, to send Server-Sent Events.