### PR TITLE
Fix not to nest framework

### DIFF
--- a/bin/copy-frameworks
+++ b/bin/copy-frameworks
@@ -11,7 +11,7 @@ do
     input_path="$(eval printf \$SCRIPT_INPUT_FILE_$i)"
     input_base="$(basename "$input_path")"
     output_path="$BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH/$input_base"
-    cp -R "$input_path" "$output_path"
+    ditto "$input_path" "$output_path"
     if [ x"$CODE_SIGNING_ALLOWED" = x'YES' ]; then
         codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" --preserve-metadata=identifier,entitlements "$output_path"
     fi


### PR DESCRIPTION
`cp -R <SRC> <DEST>` copies `SRC` into `DEST/SRC/SRC` if `DEST/SRC` already
exists.
Since build phase script may be called multiple times, this situation
frequently happens and it prevents successful code signing.

Contrary to `cp -R`, `ditto` doesn't dig into the nested directory but just
copy `SRC` into `DEST/SRC` every time it is invoked.