### PR TITLE
Fix workflow syntax

### DIFF
--- a/.github/workflows/support-new-apollo.yml
+++ b/.github/workflows/support-new-apollo.yml
@@ -6,7 +6,7 @@ on:
       - support-new-apollo
 jobs:
   support-new-apollo:
-    if: endsWith('0', github.event.client_payload.url)
+    if: endsWith(github.event.client_payload.url, '.0')
     runs-on: macOS-latest
     steps:
       - name: Export version


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#endswith
> Returns true if searchString ends with searchValue. This function is not case sensitive. Casts values to a string.