### PR TITLE
Explicitly set Apollo 0.32.0 for install tests

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "apollographql/apollo-ios" >= 0.29.0
+github "apollographql/apollo-ios" ~> 0.32.0


### PR DESCRIPTION
The change introduced in Apollo 0.33.0 breaks install tests.

https://github.com/apollographql/apollo-ios/issues/1392