### PR TITLE
Make load test less flaky

### DIFF
--- a/Tests/Classes/ApolloDebugServerLoadTests.swift
+++ b/Tests/Classes/ApolloDebugServerLoadTests.swift
@@ -37,7 +37,7 @@ class ApolloDebugServerLoadTests: XCTestCase {
 
     func testGetBundleJS_withMaximumNumberOfClients() {
         let url = server.serverURL!.appendingPathComponent("bundle.js")
-        for index in (0..<64) {
+        for index in (0..<16) {
             let expectation = self.expectation(description: "response should be received (\(index))")
             let task = session.dataTask(with: url) { data, response, error in
                 defer { expectation.fulfill() }


### PR DESCRIPTION
Revert "Heavier burden for load test"

This reverts commit 7cbbbd7c6d73d9bf86cdb83bd8db6bc9b2881284.